### PR TITLE
fix edge-case crashes, logic bugs in combat/utility modules, and reduce tick GC pressure

### DIFF
--- a/src/main/java/powie/powhax/modules/AutoEndorse.java
+++ b/src/main/java/powie/powhax/modules/AutoEndorse.java
@@ -84,7 +84,6 @@ public class AutoEndorse extends Module {
 
     @EventHandler
     private void onOpenScreen(OpenScreenEvent event) {
-        // if (mc.player == null || mc.world == null) return; // assuming that this will never happen
         if (!(event.screen instanceof AbstractSignEditScreen)) return;
 
         Entity target = getTarget(targetRange.get(), targetPriority.get());

--- a/src/main/java/powie/powhax/modules/BedrockSeedfinder.java
+++ b/src/main/java/powie/powhax/modules/BedrockSeedfinder.java
@@ -69,7 +69,7 @@ public class BedrockSeedfinder extends Module {
     private final ExecutorService executor = Executors.newSingleThreadExecutor();
 
     private volatile BufferedWriter writer;
-    private volatile int lines;
+    private int lines;
     private File outputFile;
 
     /**
@@ -96,7 +96,6 @@ public class BedrockSeedfinder extends Module {
     private void onChunkData(ChunkDataEvent event) {
         // implementation note is only a suggestion right?
         executor.execute(() -> {
-            if (writer == null) return;
             ChunkAccess c = event.chunk();
             int y = searchY.get().getValue();
             BlockPos.MutableBlockPos sPos = new BlockPos.MutableBlockPos();

--- a/src/main/java/powie/powhax/modules/BedrockSeedfinder.java
+++ b/src/main/java/powie/powhax/modules/BedrockSeedfinder.java
@@ -69,7 +69,7 @@ public class BedrockSeedfinder extends Module {
     private final ExecutorService executor = Executors.newSingleThreadExecutor();
 
     private volatile BufferedWriter writer;
-    private int lines;
+    private volatile int lines;
     private File outputFile;
 
     /**
@@ -96,13 +96,16 @@ public class BedrockSeedfinder extends Module {
     private void onChunkData(ChunkDataEvent event) {
         // implementation note is only a suggestion right?
         executor.execute(() -> {
+            if (writer == null) return;
             ChunkAccess c = event.chunk();
+            int y = searchY.get().getValue();
+            BlockPos.MutableBlockPos sPos = new BlockPos.MutableBlockPos();
             for (int x = c.getPos().getMinBlockX(); x <= c.getPos().getMaxBlockX(); x++) {
                 for (int z = c.getPos().getMinBlockZ(); z <= c.getPos().getMaxBlockZ(); z++) {
-                    BlockPos sPos = new BlockPos(x, searchY.get().getValue(), z);
-                    if (!c.getBlockState(sPos).getBlock().equals(Blocks.BEDROCK)) continue;
+                    sPos.set(x, y, z);
+                    if (!c.getBlockState(sPos).is(Blocks.BEDROCK)) continue;
                     try {
-                        writer.write(sPos.getX() + " " + sPos.getY() + " " + sPos.getZ() + " Bedrock");
+                        writer.write(x + " " + y + " " + z + " Bedrock");
                         writer.newLine();
                         lines++;
                     } catch (IOException e) {
@@ -162,6 +165,7 @@ public class BedrockSeedfinder extends Module {
 
     @Override
     public String getInfoString() {
+        if (outputFile == null) return null;
         return outputFile.getName() + " | " + lines;
     }
 

--- a/src/main/java/powie/powhax/modules/DeathCommands.java
+++ b/src/main/java/powie/powhax/modules/DeathCommands.java
@@ -93,6 +93,15 @@ public class DeathCommands extends Module {
         }
     }
 
+    @Override
+    public void onDeactivate() {
+        commandQueue.clear();
+        running = false;
+        startDelay = 0;
+        intervalDelay = 0;
+        firstCommand = true;
+    }
+
     @EventHandler
     private void onReceivePacket(PacketEvent.Receive event) {
         if (!(event.packet instanceof net.minecraft.network.protocol.game.ClientboundRespawnPacket) || running) return;

--- a/src/main/java/powie/powhax/modules/SmiteAura.java
+++ b/src/main/java/powie/powhax/modules/SmiteAura.java
@@ -160,6 +160,8 @@ public class SmiteAura extends Module {
     );
 
     private final List<Entity> targets = new ArrayList<>();
+    private final Vec3 rayStart = new Vec3(0, 0, 0);
+    private final Vec3 rayEnd = new Vec3(0, 0, 0);
     private int timer = 0;
     public boolean attacking;
     private Entity target;
@@ -261,13 +263,10 @@ public class SmiteAura extends Module {
     }
 
     public boolean canSeeEntityFeet(Entity entity) {
-        Vec3 vec1 = new Vec3(0, 0, 0);
-        Vec3 vec2 = new Vec3(0, 0, 0);
+        ((IVec3) rayStart).meteor$set(mc.player.getX(), mc.player.getY() + mc.player.getEyeHeight(), mc.player.getZ());
+        ((IVec3) rayEnd).meteor$set(entity.getX(), entity.getY(), entity.getZ());
 
-        ((IVec3) vec1).meteor$set(mc.player.getX(), mc.player.getY() + mc.player.getEyeHeight(), mc.player.getZ());
-        ((IVec3) vec2).meteor$set(entity.getX(), entity.getY(), entity.getZ());
-
-        return mc.level.clip(new ClipContext(vec1, vec2, ClipContext.Block.COLLIDER, ClipContext.Fluid.NONE, mc.player)).getType() == HitResult.Type.MISS;
+        return mc.level.clip(new ClipContext(rayStart, rayEnd, ClipContext.Block.COLLIDER, ClipContext.Fluid.NONE, mc.player)).getType() == HitResult.Type.MISS;
     }
 
     public Entity getTarget() {


### PR DESCRIPTION
- **Fixed inverted targeting filter in `AutoEndorse`:**
  In `AutoEndorse#getTarget`, the filter condition ended with `return entity instanceof FakePlayerEntity;`. Because actual players are instances of `Player` and not `FakePlayerEntity`, valid players were returning `false` and getting filtered out. This caused the module to continuously log `"no target found"` and fail to write sign text on servers. I changed the check to `!(entity instanceof FakePlayerEntity)` so it targets real players while ignoring client-side test dummies.

- **Prevented `BlazeFarm` from accidentally selling held weapons:**
  In `BlazeFarm#onTick`, if blaze rods were not found in the hotbar and `sellDelay` was greater than 600 ticks (the default is 1200), the method didn't return early. As a result, execution fell through, called `InvUtils.swap(-1, false)`, and ran `/sell handall` while the player was still holding their weapon. I updated the block to reset `sellTimer` and return immediately whenever blaze rods are missing from the hotbar.

- **Fixed `NullPointerException` and data races in `BedrockSeedfinder`:**
  If Meteor rendered module info strings on the HUD or menu while `BedrockSeedfinder` was disabled, `getInfoString()` threw a `NullPointerException` because `outputFile` is only initialized inside `onActivate()`. I added a null check to return `null` safely when inactive. I also made `lines` `volatile` and added a null check for `writer` inside the background executor to avoid race conditions and background task crashes, and switched the scanning loop to use a single `MutableBlockPos` instead of allocating 256 `BlockPos` objects per chunk.

- **Added null check for player in `FlySpeed`:**
  `FlySpeed#setSpeed` directly called `mc.player.getAbilities().setFlyingSpeed(speed)`. When disconnecting from a server while the module was active, `onDeactivate` was called after `mc.player` was already torn down, throwing an unhandled NPE. I added an `if (mc.player != null)` check to make sure cleanup runs safely.

- **Fixed disconnect NPEs and broad packet cancellation in `HandDerp`:**
  `HandDerp#onDeactivate` and `#switchHand` sent packets without verifying that `mc.player` and `mc.player.connection` were non-null, which caused crashes on server disconnect. Additionally, `onReceivePacket` was canceling `ClientboundSetEntityDataPacket` with data ID 15 for *every* entity in render distance rather than only the local player, which prevented other players and mobs from receiving visual metadata updates. I added null guards and restricted the packet check to `packet.id() == mc.player.getId()`.

- **Added `onDeactivate` state cleanup in `DeathCommands`:**
  If a player toggled `DeathCommands` off while a command queue was still running, the `running` flag stayed `true`. When re-enabling the module later, `onReceivePacket` ignored incoming respawn packets because of the `if (... || running) return;` guard, leaving the module permanently stuck until the client restarted. I added `onDeactivate` to clear the queue and reset `running`, `startDelay`, `intervalDelay`, and `firstCommand`.

- **Reused `Vec3` instances in `SmiteAura`:**
  `SmiteAura#canSeeEntityFeet` was allocating two new `Vec3` instances for every entity checked on every tick before mutating them with `((IVec3) vec).meteor$set(...)`. I converted these into reusable module-level fields (`rayStart` and `rayEnd`) to eliminate unnecessary allocations during entity scans.

- **Eliminated per-packet allocations in `AntiTrample`:**
  `AntiTrample#onSendPacket` created a 9-element array and 9 separate `BlockPos` objects via `.offset()` on every player movement packet. I refactored the 3x3 area check to use a single `BlockPos.MutableBlockPos`, keeping the exact same farmland detection logic with zero allocations on the movement hot path.